### PR TITLE
More vb flavors

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -29,9 +29,12 @@
     "VBS", "VBScript", "Language", "Symbol", "Functionlist"
   ],
   "activationEvents": [
-    "onLanguage:vbs"
+    "onLanguage:vb",
+    "onLanguage:vba",
+    "onLanguage:vbs",
+    "onLanguage:vbscript"
   ],
-  "main": "./out/src/extension",
+  "main": "./out/extension",
   "contributes": {
 	  "languages": [
 		  {
@@ -40,10 +43,6 @@
 				  "VBScript",
 				  "vbscript",
 				  "VBS"
-			  ],
-			  "extensions": [
-				  ".vbs",
-				  ".wsf"
 			  ]
 		  }
 	  ],
@@ -71,9 +70,9 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "devDependencies": {
-    "@types/node": "^8.0.26",
-    "typescript": "^2.1.5",
-    "vscode": "^1.0.3"
+    "@types/node": "8.0.26",
+    "typescript": "2.1.5",
+    "vscode": "1.0.3"
   },
   "dependencies": {
     "vscode-languageclient": "3.1.0"

--- a/client/package.json
+++ b/client/package.json
@@ -76,6 +76,6 @@
     "vscode": "^1.0.3"
   },
   "dependencies": {
-    "vscode-languageclient": "^3.1.0"
+    "vscode-languageclient": "3.1.0"
   }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: ExtensionContext) {
 	}
 
 	let clientOptions: LanguageClientOptions = {
-		documentSelector: ['vbs'],
+		documentSelector: ['vbs', 'vb', 'vbscript', 'vba'],
 		synchronize: {
 			configurationSection: 'vbsLanguageServer',
 			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')


### PR DESCRIPTION
Activate add on the for additional variations of vb language (reference issue #11).
- "VB" (built-in)
- "VBA" ([VSCode VBA](https://marketplace.visualstudio.com/items?itemName=spences10.VBA) extension)
- "VBScript" ([VBScript](https://marketplace.visualstudio.com/items?itemName=luggage66.VBScript) extension)

I believe the syntax is similar enough that the current regex method should accurately return results. It did in review of an existing VBA codebase.

Additional modifications:
- Remove the "^" modifier from some of the dependencies; presumably recent releases had some breaking changes
- Fix a path for "main" in package.json
- Remove the extension portion of the "contributes" section, since it operates based on a language instead of an extension.... but would understand if we desired to keep this section and add all known VB extension