### PR TITLE
Simplify and make greedier the method RegEx

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -413,7 +413,7 @@ let openMethod: OpenMethod = null;
 function GetMethodStart(statement: MultiLineStatement, uri: string): boolean {
 	let line = statement.GetFullStatement();
 
-	let rex:RegExp = /^\s*(?<visibility>public\s+|private\s+)?(?<type>function|sub)(\s+)(?<name>[a-zA-Z0-9\-\_]+)(\s*)(?<args>\(([a-zA-Z0-9\_\-,\s(\(\))]*)\))?\s*$/gi;
+	let rex:RegExp = /^\s*(?<visibility>public\s+|private\s+)?(?<type>function|sub)(\s+)(?<name>[a-zA-Z0-9\-\_]+)(\s*)(?<args>\(.*\))?\s*$/gi;
 	let regexResult = rex.exec(line);
 
 	if(regexResult == null || regexResult.length < 6)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -413,7 +413,7 @@ let openMethod: OpenMethod = null;
 function GetMethodStart(statement: MultiLineStatement, uri: string): boolean {
 	let line = statement.GetFullStatement();
 
-	let rex:RegExp = /^[ \t]*(public[ \t]+|private[ \t]+)?(function|sub)([ \t]+)([a-zA-Z0-9\-\_]+)([ \t]*)(\(([a-zA-Z0-9\_\-, \t(\(\))]*)\))?[ \t]*$/gi;
+	let rex:RegExp = /^\s*(?<visibility>public\s+|private\s+)?(?<type>function|sub)(\s+)(?<name>[a-zA-Z0-9\-\_]+)(\s*)(?<args>\(([a-zA-Z0-9\_\-,\s(\(\))]*)\))?\s*$/gi;
 	let regexResult = rex.exec(line);
 
 	if(regexResult == null || regexResult.length < 6)
@@ -430,15 +430,15 @@ function GetMethodStart(statement: MultiLineStatement, uri: string): boolean {
 		}
 
 		openMethod = {
-			visibility: regexResult[1],
-			type: regexResult[2],
-			name: regexResult[4],
+			visibility: regexResult.groups.visibility,
+			type: regexResult.groups.type,
+			name: regexResult.groups.name,
 			argsIndex: preLength + 1, // opening bracket
-			args: regexResult[7],
+			args: regexResult.groups.args,
 			startPosition: statement.GetPostitionByCharacter(leadingSpaces),
 			nameLocation: ls.Location.create(uri, ls.Range.create(
-				statement.GetPostitionByCharacter(line.indexOf(regexResult[3])),
-				statement.GetPostitionByCharacter(line.indexOf(regexResult[3]) + regexResult[3].length))
+				statement.GetPostitionByCharacter(line.indexOf(regexResult.groups.name)),
+				statement.GetPostitionByCharacter(line.indexOf(regexResult.groups.name) + regexResult.groups.name.length))
 			),
 			statement: statement
 		};

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,
-		"lib" : [ "es2016" ],
+		"lib" : [ "es2018" ],
 		"outDir": "../client/server",
 		"noImplicitAny": true,
         "removeComments": true


### PR DESCRIPTION
To try to fix some issues seen in #18, apply a (much) greedier args RegEx.

To help edit the RegEx, it was simplified a bit to use named groups and the `\s` whitespace character class.